### PR TITLE
fix Forbidden errors on media downloads

### DIFF
--- a/mastodon_archive/media.py
+++ b/mastodon_archive/media.py
@@ -62,7 +62,8 @@ def media(args):
             dir_name =  os.path.dirname(file_name)
             os.makedirs(dir_name, exist_ok = True)
             try:
-                with urllib.request.urlopen(url) as response, open(file_name, 'wb') as fp:
+                req = urllib.request.Request(url, data=None, headers={'User-Agent': 'Mozilla'})
+                with urllib.request.urlopen(req) as response, open(file_name, 'wb') as fp:
                     data = response.read()
                     fp.write(data)
             except OSError as e:


### PR DESCRIPTION
mastodon.social's media infrastructure rejects the `urllib` user
agent.  This changes the user agent to the generic string "Mozilla",
which makes media downloads work on mastodon.social.