### PR TITLE
Add option to include boosted toots in hashtag report

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,8 @@ You can list a different number of hashtags using `--top N` and you
 can list all of them by using `--top -1`. This might result in a very
 long list.
 
+By default only your toots are considered for the hashtags. Use `--include-boosts` to also include toot you have boosted.
+
 # Expiring your toots and favourites
 
 **Warning**: This is a destructive operation. You will delete your

--- a/mastodon_archive/__init__.py
+++ b/mastodon_archive/__init__.py
@@ -106,6 +106,9 @@ if and only if they are in your archive''')
     parser_content.add_argument("--top", dest='top',
                                 metavar='N', type=int, default=10,
                                 help='only print the top N tags')
+    parser_content.add_argument("--include-boosts", dest='include_boosts', action='store_const',
+                                const=True, default=False,
+                                help='include boosts')
     parser_content.add_argument("user",
                                 help='your account, e.g. kensanata@octogon.social')
     parser_content.set_defaults(command=report.report)

--- a/mastodon_archive/report.py
+++ b/mastodon_archive/report.py
@@ -39,12 +39,14 @@ def media(statuses):
     return i
 
 
-def tags(statuses):
+def tags(statuses, include_boosts):
     """
     Count all the hashtags in statuses
     """
     count = {}
     for item in statuses:
+        if include_boosts and item["reblog"] is not None:
+            item = item["reblog"]
         for name in [tag["name"] for tag in item["tags"]]:
             if name in count:
                 count[name] += 1
@@ -52,7 +54,7 @@ def tags(statuses):
                 count[name] = 1
     return count
 
-def print_tags(statuses, max):
+def print_tags(statuses, max, include_boosts):
     """
     Print hashtags used in statuses
     """
@@ -60,7 +62,7 @@ def print_tags(statuses, max):
         print("All the hashtags:")
     else:
         print("Top " + str(max) + " hashtags:")
-    count = tags(statuses)
+    count = tags(statuses, include_boosts)
     most = sorted(count.keys(), key = lambda tag: -count[tag])
     print(textwrap.fill(" ".join(
         ["#"+tag+"("+str(count[tag])+")" for tag in most[0:max]])))
@@ -106,7 +108,7 @@ def report(args):
         print("Media:".ljust(20), str(media(statuses)).rjust(6))
 
         print()
-        print_tags(statuses, args.top)
+        print_tags(statuses, args.top, args.include_boosts)
 
     if "statuses" in data and "favourites" in data:
         print()
@@ -117,4 +119,4 @@ def report(args):
         print("Media:".ljust(20), str(media(favourites)).rjust(6))
 
         print()
-        print_tags(favourites, args.top)
+        print_tags(favourites, args.top, args.include_boosts)


### PR DESCRIPTION
Solution for https://github.com/kensanata/mastodon-backup/issues/24.

Tested it myself: works as advertised.