### PR TITLE
Give a rough estimate when expiring toots

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,8 +372,8 @@ Visit the following URL and authorize the app:
 [long URL here]
 Then paste the access token here:
 [access token here]
-Default rate limiting is 300 requests per five minutes.
-This will take a while.
+Considering the default rate limit of 300 requests per five minutes and having 1236 statuses,
+this will take at least 20 minutes to complete.
 Expiring |#######                         | 301/1236
 ```
 

--- a/mastodon_archive/expire.py
+++ b/mastodon_archive/expire.py
@@ -16,6 +16,7 @@
 
 import sys
 import os.path
+import math
 from progress.bar import Bar
 from datetime import timedelta, datetime
 from . import core
@@ -60,14 +61,16 @@ def expire(args):
         return created < cutoff and not deleted
 
     statuses = list(filter(matches, data[collection]))
+    n_statuses = len(statuses)
 
-    if (len(statuses) == 0):
+    if (n_statuses == 0):
         print("No statuses are older than %d weeks" % args.weeks,
               file=sys.stderr)
         sys.exit(3)
-    elif (len(statuses) > 300):
-        print("Default rate limiting is 300 requests per five minutes.\n"
-              "This will take a while.")
+    elif (True or n_statuses > 300):
+        estimated_time = math.floor((n_statuses - 1) / 300) * 5
+        print("Considering the default rate limit of 300 requests per five minutes and having {} statuses,\n"
+              "this will take at least {} minutes to complete.".format(n_statuses, estimated_time))
 
     if confirmed:
 


### PR DESCRIPTION
When expiring toots, indicate to the user that it might take several minutes, due to rate limiting.

This PR is semi-tested by changing `n_statuses` to a few numbers:

- 300: ~~this is sparta!~~ reports at least 0 minutes
- 301: reports at least 5 minutes
- 1236: reports at least 20 minutes
- 1500: idem

It doesn't yet use the actual rate limits reported by the server, nonetheless, it seems rare for instances to deviate from the default.