### PR TITLE
expire.py : Add reblog type to unreblog

### DIFF
--- a/mastodon_archive/expire.py
+++ b/mastodon_archive/expire.py
@@ -42,7 +42,7 @@ def delete(mastodon, collection, status):
     """
     if collection == 'statuses':
         if status["reblog"]:
-            mastodon.status_unreblog(status["id"])
+            mastodon.status_unreblog(status["reblog"]["id"])
         else:
             mastodon.status_delete(status["id"])
     elif collection == 'favourites':


### PR DESCRIPTION
Add ["reblog"] status type to the unreblog function because just ["id"] let some boosted statuses and does not unreblog them.
See https://github.com/kensanata/mastodon-backup/issues/40