### PR TITLE
import mastodon_archive.core for core.load

### DIFF
--- a/mastodon_archive/media.py
+++ b/mastodon_archive/media.py
@@ -23,6 +23,7 @@ from urllib.error import HTTPError
 from urllib.error import URLError
 from progress.bar import Bar
 from urllib.parse import urlparse
+from . import core
 
 def media(args):
     """


### PR DESCRIPTION
Getting this with current master:

```
mastodon-archive media --pace myaccount@example.com
(…)
  File "/usr/local/lib/python3.7/dist-packages/mastodon_archive/media.py", line 38, in media
    data = core.load(status_file, required=True, quiet=True, combine=args.combine)
NameError: name 'core' is not defined
```