### PR TITLE
Search content warnings field when using "mastodon-archive text"

### DIFF
--- a/mastodon_archive/text.py
+++ b/mastodon_archive/text.py
@@ -42,6 +42,7 @@ def text(args):
         for pattern in patterns:
             found = False
             for s in [status["content"],
+                      status["spoiler_text"],
                       status["account"]["display_name"],
                       status["account"]["username"],
                       status["created_at"]]:
@@ -74,6 +75,7 @@ def text(args):
             status["account"]["username"],
             status["created_at"]))
         str += status["url"] + "\n"
+        str += "CW: %s\n" % status["spoiler_text"]
         str += html2text.html2text(status["content"])
         # This forces UTF-8 independent of terminal capabilities, thus
         # avoiding problems with LC_CTYPE=C and other such issues.


### PR DESCRIPTION
Hi,

In basically all cases that I want to search toots and display their text content, I also want to search and display the content warnings (CWs) text. So I made this little modification for my own use.  Maybe you want to integrate it, perhaps behind an option if you think that's better. Feel free to edit or discard this.

Thanks for the tool 🙏