### PR TITLE
Fix status insertion order when downloading new statuses

### DIFF
--- a/mastodon_archive/archive.py
+++ b/mastodon_archive/archive.py
@@ -88,7 +88,7 @@ def archive(args):
                         if not id in seen:
                             if func is None or func(item):
                                 seen["id"] = status
-                                statuses.append(status)
+                                statuses.insert(count, status)
                                 count = count + 1
                         else:
                             duplicates = duplicates + 1

--- a/mastodon_archive/core.py
+++ b/mastodon_archive/core.py
@@ -262,6 +262,8 @@ def load(file_name, required=False, quiet=False, combine=False):
                 for collection in ["statuses", "favourites", "mentions"]:
                     data[collection].extend(archived_data[collection])
 
+        data["statuses"].sort(key=lambda x: x["created_at"], reverse=True)
+
         return data
 
     return None


### PR DESCRIPTION
Currently, Mastodon Archive inserts statuses in reverse chronological order on first load. But the next time you run it, it again downloads your new posts in reverse chronological order, and appends them *at the end* of the array of existing posts. This messes up the order in Meow and in HTML export — if you had never split your archive, you can generate the report and see that the order is wrong. E. g. if you run it at 2021-08-01 for the first time, and then again at 2021-08-05, you'll get the following post order:
- 2021-08-01
- 2021-07-31
- 2021-07-30
- 2021-07-29
- 2021-08-05
- 2021-08-04
- 2021-08-03
- 2021-08-02

This pull request fixes the insertion order. Additionally, it will sort user's own statuses after loading them from existing JSON, so that existing archives, which have been created before the fix, work correctly. Unfortunately, we can't do the same for favourites, because data returned from API only contains the favourited post publication date, but not the date at which the user favourited it.