### PR TITLE
add contrib: wrapper script to ease usage, install debs via Debian packages

### DIFF
--- a/contrib/debinstall.sh
+++ b/contrib/debinstall.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # install mastodon-backup via Debian packages instead of PyPi dependencies
+# © 2022 Izzy <izzysoft AT qumran DOT org>; GPL-3.0-or-later
 
 #
 # define temp dir and exit-on-error
@@ -17,14 +18,14 @@ trap cleanup ERR
 # ==============
 # ===[ Main ]===
 # ==============
-#
+# -----------------------------------------------------------------------------
 # install Debian packages
 echo
 echo "Installing required Debian packages via APT. You will need to provide your"
 echo "password for sudo here:"
 sudo apt install python3-progress python3-mastodon
 
-#
+# -----------------------------------------------------------------------------
 # check whether we need to update python3-mastodon
 echo
 echo "Let's see if your distribution had the recent version of python3-mastodon…"
@@ -45,7 +46,7 @@ else
   rm -rf $tmpdir
 fi
 
-#
+# -----------------------------------------------------------------------------
 # take care for the wrapper script
 echo
 echo "Looking for the wrapper script…"
@@ -63,7 +64,7 @@ EOF
   chmod o+x ../mastodon-archive.py
 fi
 
-#
+# -----------------------------------------------------------------------------
 # Finito
 bindir=$(dirname $(realpath .))
 echo

--- a/contrib/debinstall.sh
+++ b/contrib/debinstall.sh
@@ -30,7 +30,9 @@ echo
 echo "Let's see if your distribution had the recent version of python3-mastodon…"
 mver="$(dpkg -l python3-mastodon |tail -n 1 |awk '{print $3}')"
 mver="${mver%%-*}"
-if [[ "$mver" = "1.5.1" ]]; then
+IFS='.'; arr=($mver); unset IFS
+typeset -i vercode=${arr[0]}+${arr[1]}*100+${arr[0]}*10000
+if [[ "$mver" -gt 10500 ]]; then    # we need at least v1.5.1 = 10501
   echo "Found version '$mver' – all is fine!"
 else
   echo "Found version '$mver' – that's too old. Let's get v1.5.1 and replace the required files."

--- a/contrib/debinstall.sh
+++ b/contrib/debinstall.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# install mastodon-backup via Debian packages instead of PyPi dependencies
+
+#
+# define temp dir and exit-on-error
+function cleanup() {
+  echo
+  echo "Something went wrong, aborting."
+  rm -rf $tmpdir
+  exit 1
+}
+
+tmpdir=$(mktemp -d)
+trap cleanup ERR
+
+
+# ==============
+# ===[ Main ]===
+# ==============
+#
+# install Debian packages
+echo
+echo "Installing required Debian packages via APT. You will need to provide your"
+echo "password for sudo here:"
+sudo apt install python3-progress python3-mastodon
+
+#
+# check whether we need to update python3-mastodon
+echo
+echo "Let's see if your distribution had the recent version of python3-mastodon…"
+mver="$(dpkg -l python3-mastodon |tail -n 1 |awk '{print $3}')"
+mver="${mver%%-*}"
+if [[ "$mver" = "1.5.1" ]]; then
+  echo "Found version '$mver' – all is fine!"
+else
+  echo "Found version '$mver' – that's too old. Let's get v1.5.1 and replace the required files."
+  echo "Downloading, extracting and copying (via sudo) files"
+  cd $tmpdir
+  wget https://files.pythonhosted.org/packages/7c/80/f12b205fc529fff8e3245fe8e6cafb870f1783476449d3ea2a32b40928c5/Mastodon.py-1.5.1-py2.py3-none-any.whl
+  unzip Mastodon.py-1.5.1-py2.py3-none-any.whl
+  sudo cp mastodon/__init__.py mastodon/Mastodon.py mastodon/streaming.py /usr/lib/python3/dist-packages/mastodon
+  cd - >/dev/null
+  rm -rf $tmpdir
+fi
+
+#
+# take care for the wrapper script
+echo
+echo "Looking for the wrapper script…"
+if [[ -f ../mastodon-archive.py ]]; then
+  echo "'mastodon-archive.py' already exists, skipping creation."
+else
+  echo "'mastodon-archive.py' not found, generating…"
+  cat > ../mastodon-archive.py <<EOF
+#!/usr/bin/env python3
+import mastodon_archive
+
+if __name__ == "__main__":
+  mastodon_archive.main()
+EOF
+  chmod o+x ../mastodon-archive.py
+fi
+
+#
+# Finito
+bindir=$(dirname $(realpath .))
+echo
+echo "All is prepared now. You either can…"
+echo "- run './mastodon-archive.py' from within '${bindir}',"
+echo "- add '${bindir}' to your '\$PATH' to be able to call it from anywhere, or"
+echo "- set up an 'alias mastodon-archive=\"${bindir}/mastodon-archive.py\"'"
+echo "for the same purpose."
+echo "Enjoy!"
+echo

--- a/contrib/debinstall.sh
+++ b/contrib/debinstall.sh
@@ -31,8 +31,8 @@ echo "Let's see if your distribution had the recent version of python3-mastodon�
 mver="$(dpkg -l python3-mastodon |tail -n 1 |awk '{print $3}')"
 mver="${mver%%-*}"
 IFS='.'; arr=($mver); unset IFS
-typeset -i vercode=${arr[0]}+${arr[1]}*100+${arr[0]}*10000
-if [[ "$mver" -gt 10500 ]]; then    # we need at least v1.5.1 = 10501
+typeset -i vercode=${arr[2]}+${arr[1]}*100+${arr[0]}*10000
+if [[ $vercode -gt 10500 ]]; then    # we need at least v1.5.1 = 10501
   echo "Found version '$mver' – all is fine!"
 else
   echo "Found version '$mver' – that's too old. Let's get v1.5.1 and replace the required files."

--- a/contrib/debinstall.sh
+++ b/contrib/debinstall.sh
@@ -2,7 +2,7 @@
 # install mastodon-backup via Debian packages instead of PyPi dependencies
 # © 2022 Izzy <izzysoft AT qumran DOT org>; GPL-3.0-or-later
 
-#
+# -----------------------------------------------------------------------------
 # define temp dir and exit-on-error
 function cleanup() {
   echo
@@ -39,7 +39,7 @@ else
   echo "Found version '$mver' – that's too old. Let's get v1.5.1 and replace the required files."
   echo "Downloading, extracting and copying (via sudo) files"
   cd $tmpdir
-  wget https://files.pythonhosted.org/packages/7c/80/f12b205fc529fff8e3245fe8e6cafb870f1783476449d3ea2a32b40928c5/Mastodon.py-1.5.1-py2.py3-none-any.whl
+  wget -q --show-progress https://files.pythonhosted.org/packages/7c/80/f12b205fc529fff8e3245fe8e6cafb870f1783476449d3ea2a32b40928c5/Mastodon.py-1.5.1-py2.py3-none-any.whl
   unzip Mastodon.py-1.5.1-py2.py3-none-any.whl
   sudo cp mastodon/__init__.py mastodon/Mastodon.py mastodon/streaming.py /usr/lib/python3/dist-packages/mastodon
   cd - >/dev/null

--- a/contrib/mastoarch
+++ b/contrib/mastoarch
@@ -1,0 +1,112 @@
+#!/bin/bash
+# Script to automate your Mastodon backup. Run it without any arguments to show its usage.
+# You can use this cript e.g. via Cron for automated backups of your Mastodon account.
+# A command for cron could be: "cd /path/to/mastoarch && ./mastoarch archive >/dev/null"
+
+# Put in your Mastodon handle here:
+myacc="Demo@server.tld"
+# whether to automatically check-in new data to your local git repo
+autogit=0
+
+# !!! ================================================================== !!!
+# !!! Do not change below this line unless you know what you're doing :) !!!
+# !!! ================================================================== !!!
+
+if [[ "$myacc" = "Demo@server.tld" && -n "$1" ]]; then
+  echo
+  echo "You must configure your Mastodon-handle before running this script!"
+  echo
+  exit 1
+fi
+
+basename="${myacc##*@}.user.${myacc%%@*}"
+
+syntax() {
+  echo
+  echo "Mastodon Archiver"
+  echo "================="
+  echo
+  echo "Syntax:"
+  echo "  $0 archive|html|backup|report|help [autogit]"
+  echo
+  echo "archive: get data from the instance"
+  echo "html   : generate static html from gathered data"
+  echo "backup : archive & html"
+  echo "report : show some stats"
+  echo "help   : show this help page and exit"
+  echo
+  echo "autogit: whether to automatically check in changes to your local git (0|1)"
+  echo
+}
+
+# get data from the instance
+function archive() {
+  mastodon-archive archive --with-mentions --with-following "$myacc"
+  mastodon-archive replies "$myacc"
+  mastodon-archive media --collection favourites "$myacc"
+  mastodon-archive media --collection bookmarks "$myacc"
+}
+
+# generate static html from gathered data
+function html() {
+  mastodon-archive html "$myacc"
+  mastodon-archive html --collection favourites "$myacc"
+}
+
+# add changes to local git repo
+function save() {
+  [[ ! -d .git ]] && {
+    echo "No git repo found, skipping check-in."
+    echo "(Use 'git init' to create a repo.)"
+    return
+  }
+  if [[ $autogit -eq 1 ]]; then
+    gitreply=y
+  else
+    read -n 1 -t 600 -p "run 'git add' and 'git commit' (y/n)? " gitreply
+    echo
+  fi
+  [[ ${gitreply,,} = 'y' || ${gitreply,,} = 'j' ]] && {
+    git add .
+    git commit -m "commit for backup after run at $(date +'%y-%m-%y %H:%M:%S')"
+  }
+}
+
+# show some stats
+function report() {
+  echo
+  echo "Account Statistics:"
+  echo "==================="
+  echo
+  mastodon-archive report --all "$myacc"
+  echo
+  echo "Followers who follow us back:"
+  echo "-----------------------------"
+  mastodon-archive mutuals "$myacc" | grep -iv "Get user info"
+  echo
+  echo "$(mastodon-archive mutuals "$myacc" | grep -iv "Get user info" | wc -l) Followers follow us back."
+  echo
+  echo "Header info:"
+  echo "------------"
+  echo "Statuses: $(jq .account.statuses_count ${basename}.json)"
+  echo "Followers: $(jq .account.followers_count ${basename}.json)"
+  echo "Following: $(jq .account.following_count ${basename}.json)"
+  echo "Last status: $(jq .account.last_status_at ${basename}.json | awk -F \" '{print $2}' | awk -F T '{print $1}')"
+  echo "Account created: $(jq .account.created_at ${basename}.json | awk -F \" '{print $2}' | awk -F T '{print $1}')"
+  echo
+}
+
+#===[ MAIN ]===
+# autogit override?
+case "$2" in
+  0|1) autogit=$2
+esac
+
+# What to do?
+case "$1" in
+  archive) archive && save;;
+  html) html && save;;
+  backup) archive && html && save;;
+  report) report;;
+  *) syntax;;
+esac

--- a/contrib/mastoarch
+++ b/contrib/mastoarch
@@ -1,25 +1,29 @@
 #!/bin/bash
 # Script to automate your Mastodon backup. Run it without any arguments to show its usage.
-# You can use this cript e.g. via Cron for automated backups of your Mastodon account.
+# © 2022 Izzy <izzysoft AT qumran DOT org>; GPL-3.0-or-later
+#
+# You can use this script e.g. via Cron for automated backups of your Mastodon account.
 # A command for cron could be: "cd /path/to/mastoarch && ./mastoarch archive >/dev/null"
 
-# Put in your Mastodon handle here:
-myacc="Demo@server.tld"
-# whether to automatically check-in new data to your local git repo
-autogit=0
+# -----------------------------------------------------------------------------
+# Default options (can be overridden via command-line):
+myacc="Demo@server.tld" # Your (default) Mastodon handle
+autogit=0               # whether to automatically check-in new data to your local git repo
 
 # !!! ================================================================== !!!
 # !!! Do not change below this line unless you know what you're doing :) !!!
 # !!! ================================================================== !!!
 
-#
+# -----------------------------------------------------------------------------
 # Evaluate command-line options
 while getopts "a:g:" OPT; do
   case $OPT in
     a) myacc=$OPTARG ;;
     g) case "$OPTARG" in
          0|1) autogit=$OPTARG ;;
-         *) echo "! ignoring invalid value for autogit. -g must be 0 or 1." ; exit 1 ;;
+         *) echo "! invalid value '$OPTARG' for autogit. -g must be 0 or 1."
+            exit 1
+            ;;
        esac
        ;;
     *) $0 ; exit 1 ;;
@@ -27,18 +31,7 @@ while getopts "a:g:" OPT; do
 done
 shift $(($OPTIND - 1))
 
-#
-# sanity check
-if [[ "$myacc" = "Demo@server.tld" && -n "$1" ]]; then
-  echo
-  echo "You must configure your Mastodon-handle before running this script!"
-  echo
-  exit 1
-fi
-
-basename="${myacc##*@}.user.${myacc%%@*}"
-
-#
+# -----------------------------------------------------------------------------
 # show help
 syntax() {
   echo
@@ -61,6 +54,17 @@ syntax() {
   echo
 }
 
+# -----------------------------------------------------------------------------
+# sanity check
+if [[ "$myacc" = "Demo@server.tld" && -n "$1" ]]; then
+  syntax
+  echo "You must configure your Mastodon-handle before running this script,"
+  echo "or pass it via the '-a' option."
+  echo
+  exit 1
+fi
+
+# -----------------------------------------------------------------------------
 # get data from the instance
 function archive() {
   mastodon-archive archive --with-mentions --with-following "$myacc"
@@ -69,12 +73,14 @@ function archive() {
   mastodon-archive media --collection bookmarks "$myacc"
 }
 
+# -----------------------------------------------------------------------------
 # generate static html from gathered data
 function html() {
   mastodon-archive html "$myacc"
   mastodon-archive html --collection favourites "$myacc"
 }
 
+# -----------------------------------------------------------------------------
 # add changes to local git repo
 function save() {
   [[ ! -d .git ]] && {
@@ -90,15 +96,19 @@ function save() {
   fi
   [[ ${gitreply,,} = 'y' || ${gitreply,,} = 'j' ]] && {
     git add .
-    git commit -m "commit for backup after run at $(date +'%y-%m-%y %H:%M:%S')"
+    git commit -m "commit for backup after run for '$1' at $(date +'%y-%m-%y %H:%M:%S')"
   }
 }
 
+# -----------------------------------------------------------------------------
 # show some stats
 function report() {
+  basename="${myacc##*@}.user.${myacc%%@*}"
   echo
   echo "Account Statistics:"
   echo "==================="
+  echo
+  echo "Account: ${myacc}"
   echo
   mastodon-archive report --all "$myacc"
   echo
@@ -121,9 +131,9 @@ function report() {
 #===[ MAIN ]===
 # What to do?
 case "$1" in
-  archive) archive && save;;
-  html) html && save;;
-  backup) archive && html && save;;
+  archive) archive && save archive;;
+  html) html && save html;;
+  backup) archive && html && save backup;;
   report) report;;
   *) syntax;;
 esac

--- a/contrib/mastoarch
+++ b/contrib/mastoarch
@@ -12,6 +12,23 @@ autogit=0
 # !!! Do not change below this line unless you know what you're doing :) !!!
 # !!! ================================================================== !!!
 
+#
+# Evaluate command-line options
+while getopts "a:g:" OPT; do
+  case $OPT in
+    a) myacc=$OPTARG ;;
+    g) case "$OPTARG" in
+         0|1) autogit=$OPTARG ;;
+         *) echo "! ignoring invalid value for autogit. -g must be 0 or 1." ; exit 1 ;;
+       esac
+       ;;
+    *) $0 ; exit 1 ;;
+  esac
+done
+shift $(($OPTIND - 1))
+
+#
+# sanity check
 if [[ "$myacc" = "Demo@server.tld" && -n "$1" ]]; then
   echo
   echo "You must configure your Mastodon-handle before running this script!"
@@ -21,21 +38,26 @@ fi
 
 basename="${myacc##*@}.user.${myacc%%@*}"
 
+#
+# show help
 syntax() {
   echo
   echo "Mastodon Archiver"
   echo "================="
   echo
   echo "Syntax:"
-  echo "  $0 archive|html|backup|report|help [autogit]"
+  echo "  $0 [options] <command>"
   echo
-  echo "archive: get data from the instance"
-  echo "html   : generate static html from gathered data"
-  echo "backup : archive & html"
-  echo "report : show some stats"
-  echo "help   : show this help page and exit"
+  echo "Commands:"
+  echo "  archive: get data from the instance"
+  echo "  html   : generate static html from gathered data"
+  echo "  backup : archive & html"
+  echo "  report : show some stats"
+  echo "  help   : show this help page and exit"
   echo
-  echo "autogit: whether to automatically check in changes to your local git (0|1)"
+  echo "Options:"
+  echo "  -g <0|1>    : whether to automatically check in changes to your local git (0|1)"
+  echo "  -a <handle> : Mastodon handle (user) to process"
   echo
 }
 
@@ -97,11 +119,6 @@ function report() {
 }
 
 #===[ MAIN ]===
-# autogit override?
-case "$2" in
-  0|1) autogit=$2
-esac
-
 # What to do?
 case "$1" in
   archive) archive && save;;


### PR DESCRIPTION
Starting on the contrib scripts. This will entail 2 scripts:

* a wrapper script (`mastoarch`) to ease and automate things
* an installer script for a more "Debian-like" install (using packages instead of PyPi), see #78 

closes #78 