### PR TITLE
split out wrapper scripts from debinstall.sh and add README

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,53 @@
+# Contrib
+This directory contains user-provided contributions intended to enhance
+mastodon-backup.
+
+## `upgrade_python-mastodon.sh` (by Izzy)
+A script intended to upgrade outdated versions of `Mastodon.py` when installed
+via your Linux distribution's package manager. As of this writing,
+mastodon-backup requires at least v1.5.1 of it for full functionality. It will
+work with v1.5.0 but then lack sone features (e.g. bookmark operations are not
+available). Some distributions ship even older versions. We explicitly decided
+against requiring a specific version in the package's dependencies as that would
+make the package unavailable for many LTS distributions, while the underlying
+issue can easily be solved – by this script.
+
+What it does:
+
+* you call it from within this directory without any parameters
+* it uses your package manager (`dpkg` or `yum`) to find out which version of
+  `python3-mastodon` (DEB) or `python3-Mastodon` (RPM) is installed
+* if it cannot find out (no `dpkg`/`yum` found or package not installed) it
+  will inform you. You can then decide to proceed anyhow – or to use your
+  package manager to install (this situation should not happen if you installed
+  mastodon-backup via `apt`/`yum`, but who knows
+* if a proper version (1.5.1 or later) was found, it says Good-Bye
+* else it checks if the target directory & module exists. If not, it will abort.
+* now it downloads the code from PyPi and replaces the existing old version
+  located in `/usr/lib/python3/dist-packages/mastodon`.
+
+Before any action takes place, you'll always be asked to confirm.
+
+## `mastoarch` (by Izzy)
+This is a wrapper for automation – intended to keep a close-to-complete copy
+of your Mastodon account on your disk. Simply call it without parameters to
+get details on its usage.
+
+It will work in the directory you called it from. So if you wish to use it, I'd
+recommend you either put it into your `$PATH` or create yourself an alias for it.
+
+Once you've set it up and have it running, you could even have a Cron job
+taken care for regular runs. Here I'd recommend the following command line:
+
+```bash
+cd /path/to/archive && mastoarch -a Me@MyInstance 2>/dev/null
+```
+
+If you've initialized a git repo with your archive, you could include `-g 1`
+with the call to have changes committed automatically.
+
+## `mastodon-archive` (by Izzy)
+`mastodon-archive` and `mastodon-archive.py` are wrapper scripts. The latter is
+usually created automatically when installing via PyPi, the former is intended
+to go to `/usr/bin` (or somewhere else in your `$PATH`). Both are used with the
+DEB/RPM packages maintained by me.

--- a/contrib/mastodon-archive
+++ b/contrib/mastodon-archive
@@ -1,2 +1,2 @@
 #!/bin/bash
-/usr/lib/python3/dist-packages/mastodon-backup/mastodon-backup/mastodon-archive.py $*
+/usr/lib/python3/dist-packages/mastodon-backup/mastodon-archive.py $*

--- a/contrib/mastodon-archive
+++ b/contrib/mastodon-archive
@@ -1,0 +1,2 @@
+#!/bin/bash
+/usr/lib/python3/dist-packages/mastodon-backup/mastodon-backup/mastodon-archive.py $*

--- a/contrib/mastodon-archive.py
+++ b/contrib/mastodon-archive.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+import mastodon_archive
+
+if __name__ == "__main__":
+  mastodon_archive.main()

--- a/contrib/upgrade_python-mastodon.sh
+++ b/contrib/upgrade_python-mastodon.sh
@@ -26,13 +26,13 @@ trap cleanup ERR
 # -----------------------------------------------------------------------------
 # check whether we need to update python3-mastodon
 echo
-echo "Let's see if your distribution had the recent version of python3-mastodon…"
+echo "Let's see if your distribution had the recent version of python3-mastodon..."
 if [[ -f /etc/debian_versions ]]; then
   mver="$(dpkg -l python3-mastodon |tail -n 1 |awk '{print $3}')"
 elif [[ -f /etc/redhat_release || -f /etc/fedora-release ]]; then
   mver="$(yum info python3-Mastodon |grep -Ei '^Version' |awk '{print $3}')"
 else
-  read -n 1 -p "Could not find out whether your system is DEB or RPM based. Continue anyway? (y/n) " REPLY
+  read -n 1 -p "Could not determine whether your system is DEB or RPM based. Continue anyway? (y/n) " REPLY
   if [[ "${REPLY,,}" = 'y' || "${REPLY,,}" = 'j' ]]; then
     echo
     echo "Assuming package version 1.5.0 to continue."


### PR DESCRIPTION
* split out the wrapper scripts from `contrib/debinstall.sh` to make the packaging SPEC file cleaner:
  * `contrib/mastodon-archive` is intended to into `/usr/bin` with packaging, but can also serve as an example wrapper script for manual install
  * `contrib/mastodon-archive.py` is to be placed into the module's main directory by the packaging process – but can also help solving issues like #77 
* `contrib/README.md` describes purpose and content of `contrib/`. Note that `debinstall.sh` was left out intentionally as it will become obsolete once the DEB/RPM packages are available
* minor spelling/phrasing corrections to `upgrade_python-mastodon.sh` were applied as suggested by #81 