### PR TITLE
add config & mastosearch, update mastoarch & README

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,11 +1,11 @@
 # Contrib
 This directory contains user-provided contributions intended to enhance
-mastodon-backup.
+mastodon-archive.
 
 ## `upgrade_python-mastodon.sh` (by Izzy)
 A script intended to upgrade outdated versions of `Mastodon.py` when installed
 via your Linux distribution's package manager. As of this writing,
-mastodon-backup requires at least v1.5.1 for full functionality. It will
+mastodon-archive requires at least v1.5.1 for full functionality. It will
 work with v1.5.0 with reduced functionality (e.g. bookmark operations are not
 available). Some distributions ship even older versions. We explicitly decided
 against requiring a specific version in the package's dependencies as that would
@@ -20,7 +20,7 @@ What it does:
 * if it cannot find out (no `dpkg`/`yum` found or package not installed) it
   will inform you. You can then decide to proceed anyhow – or to use your
   package manager to install (this situation should not happen if you installed
-  mastodon-backup via `apt`/`yum`, but who knows
+  mastodon-archive via `apt`/`yum`, but who knows
 * if a proper version (1.5.1 or later) was found, it says Good-Bye
 * else it checks if the target directory & module exists. If not, it will abort.
 * now it downloads the code from PyPi and replaces the existing old version
@@ -62,7 +62,7 @@ called without parameters.
 ## `config.sample` (by Izzy)
 Lets you define defaults to use with `mastoarch` and `mastosearch` to make
 calls to them as simple as possible. On your Linux machine, copy it to
-`${HOME}/.config/mastodon-backup/config` and adjust it to fit your needs.
+`${HOME}/.config/mastodon-archive/config` and adjust it to fit your needs.
 Hints inside. This file is optional, defaults are defined in the scripts
 and can be overridden using command-line parameters.
 

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -46,6 +46,18 @@ cd /path/to/archive && mastoarch -a Me@MyInstance 2>/dev/null
 If you've initialized a git repo with your archive, you could include `-g 1`
 with the call to have changes committed automatically.
 
+## `mastosearch` (by Izzy)
+For your impromptu searches. Again a wrapper around the main script intended
+to be easy to use. With your defaults set up in the configuration, a search
+is as easy as `mastosearch <searchterm>`. Again, the full syntax is shown when
+called without parameters.
+
+## `config.sample` (by Izzy)
+Lets you define defaults to use with `mastoarch` and `mastosearch` to make
+calls to them as simple as possible. On your Linux machine, copy it to
+`${HOME}/.config/mastodon-backup/config` and adjust it to fit your needs.
+Hints inside.
+
 ## `mastodon-archive` (by Izzy)
 `mastodon-archive` and `mastodon-archive.py` are wrapper scripts. The latter is
 usually created automatically when installing via PyPi, the former is intended

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -37,13 +37,20 @@ It will work in the directory you called it from. So if you wish to use it, I'd
 recommend you either put it into your `$PATH` or create yourself an alias for it.
 
 Once you've set it up and have it running, you could even have a Cron job
-taken care for regular runs. Here I'd recommend the following command line:
+taken care for regular runs. With the config set up properly, the command
+for that job could look like this:
 
 ```bash
-cd /path/to/archive && mastoarch -a Me@MyInstance 2>/dev/null
+source /home/johndoe && mastoarch archive
 ```
 
-If you've initialized a git repo with your archive, you could include `-g 1`
+or, alternatively:
+
+```bash
+cd /path/to/archive && mastoarch -a Me@MyInstance -b "" 2>/dev/null
+```
+
+If you've initialized a git repo with your archive, you could include `-g 2`
 with the call to have changes committed automatically.
 
 ## `mastosearch` (by Izzy)

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -41,7 +41,7 @@ taken care for regular runs. With the config set up properly, the command
 for that job could look like this:
 
 ```bash
-source /home/johndoe && mastoarch archive
+source /home/johndoe/.profile && mastoarch archive
 ```
 
 or, alternatively:
@@ -63,7 +63,8 @@ called without parameters.
 Lets you define defaults to use with `mastoarch` and `mastosearch` to make
 calls to them as simple as possible. On your Linux machine, copy it to
 `${HOME}/.config/mastodon-backup/config` and adjust it to fit your needs.
-Hints inside.
+Hints inside. This file is optional, defaults are defined in the scripts
+and can be overridden using command-line parameters.
 
 ## `mastodon-archive` (by Izzy)
 `mastodon-archive` and `mastodon-archive.py` are wrapper scripts. The latter is

--- a/contrib/config.sample
+++ b/contrib/config.sample
@@ -9,6 +9,12 @@ MASTOBASE=
 # default account (mastoarch, mastosearch)
 myacc=Demo@Mastodon.example.net
 
+# shall followers be archived as well? (mastoarch)
+# this is currently of limited use, hence disabled by default. It will not only
+# collect user IDs, but the entire profile info; expect about 1.5kB per profile.
+# 0: no, 1: yes
+archive_followers=0
+
 # automatically backup to git (mastoarch)
 # 0: never, 1: ask, 2: do it
 autogit=0

--- a/contrib/config.sample
+++ b/contrib/config.sample
@@ -1,0 +1,21 @@
+# Example config file for the contrib tools.
+# copy this to ${HOME}/.config/mastodon-backup/config and adjust to your needs.
+
+# base where all our backups reside (mastosearch)
+# If you define MASTOBASE, your backups are looked for in $MASTOBASE/<ServerName>
+# Otherwise they are looked for in the current working directory.
+MASTOBASE=
+
+# use a specific viewer (mastosearch).
+# This needs markdown being available (e.g. to use lynx on Debian:
+# 'apt install markdown lynx').
+# The viewer should accept HTML from STDIN (standard input).
+# If empty, results will simply be printed on your console.
+#viewer="lynx -stdin"
+viewer=
+
+# default account (mastoarch, mastosearch)
+myacc=Demo@Mastodon.example.net
+
+# automatically backup to git (mastoarch)
+autogit=0

--- a/contrib/config.sample
+++ b/contrib/config.sample
@@ -1,10 +1,16 @@
 # Example config file for the contrib tools.
 # copy this to ${HOME}/.config/mastodon-backup/config and adjust to your needs.
 
-# base where all our backups reside (mastosearch)
+# base where all our backups reside (mastoarch, mastosearch)
 # If you define MASTOBASE, your backups are looked for in $MASTOBASE/<ServerName>
 # Otherwise they are looked for in the current working directory.
 MASTOBASE=
+
+# default account (mastoarch, mastosearch)
+myacc=Demo@Mastodon.example.net
+
+# automatically backup to git (mastoarch)
+autogit=0
 
 # use a specific viewer (mastosearch).
 # This needs markdown being available (e.g. to use lynx on Debian:
@@ -13,9 +19,3 @@ MASTOBASE=
 # If empty, results will simply be printed on your console.
 #viewer="lynx -stdin"
 viewer=
-
-# default account (mastoarch, mastosearch)
-myacc=Demo@Mastodon.example.net
-
-# automatically backup to git (mastoarch)
-autogit=0

--- a/contrib/config.sample
+++ b/contrib/config.sample
@@ -10,6 +10,7 @@ MASTOBASE=
 myacc=Demo@Mastodon.example.net
 
 # automatically backup to git (mastoarch)
+# 0: never, 1: ask, 2: do it
 autogit=0
 
 # use a specific viewer (mastosearch).

--- a/contrib/config.sample
+++ b/contrib/config.sample
@@ -1,5 +1,5 @@
 # Example config file for the contrib tools.
-# copy this to ${HOME}/.config/mastodon-backup/config and adjust to your needs.
+# copy this to ${HOME}/.config/mastodon-archive/config and adjust to your needs.
 
 # base where all our backups reside (mastoarch, mastosearch)
 # If you define MASTOBASE, your backups are looked for in $MASTOBASE/<ServerName>

--- a/contrib/mastoarch
+++ b/contrib/mastoarch
@@ -17,7 +17,7 @@ autogit=0               # whether to automatically check-in new data to your loc
 
 # -----------------------------------------------------------------------------
 # Load config if exists
-[[ -f "${HOME}/.config/mastodon-backup/config" ]] && source "${HOME}/.config/mastodon-backup/config"
+[[ -f "${HOME}/.config/mastodon-archive/config" ]] && source "${HOME}/.config/mastodon-archive/config"
 
 # -----------------------------------------------------------------------------
 # Evaluate command-line options
@@ -73,7 +73,7 @@ syntax() {
   echo "                    git (0: don't, 1: ask, 2: do it)"
   echo
   echo "Note that you can define your defaults (myacc, autogit) in"
-  echo "${HOME}/.config/mastodon-backup/config"
+  echo "${HOME}/.config/mastodon-archive/config"
   echo
 }
 

--- a/contrib/mastoarch
+++ b/contrib/mastoarch
@@ -20,9 +20,10 @@ autogit=0               # whether to automatically check-in new data to your loc
 
 # -----------------------------------------------------------------------------
 # Evaluate command-line options
-while getopts "a:g:" OPT; do
+while getopts "a:b:g:" OPT; do
   case $OPT in
     a) myacc=$OPTARG ;;
+    b) MASTOBASE="$OPTARG" ;;
     g) case "$OPTARG" in
          0|1) autogit=$OPTARG ;;
          *) echo "! invalid value '$OPTARG' for autogit. -g must be 0 or 1."
@@ -53,8 +54,15 @@ syntax() {
   echo "  help   : show this help page and exit"
   echo
   echo "Options:"
-  echo "  -g <0|1>    : whether to automatically check in changes to your local git (0|1)"
-  echo "  -a <handle> : Mastodon handle (user) to process"
+  echo "  -a <handle>     : Mastodon handle (user) to process"
+  echo "  -b <MASTOBASE>  : base where all our backups reside. If specified,"
+  echo "                    your backups are expected in MASTOBASE/<instanceName>"
+  echo "                    (e.g. /home/peter/mastodon/mastodon.example.net if"
+  echo "                    your account is @<username>@mastodon.example.net),"
+  echo "                    otherwise they will be looked for in your current"
+  echo "                    working directory (where you are when invoking this script)"
+  echo "  -g <0|1>        : whether to automatically check in changes to your local"
+  echo "                    git (0|1)"
   echo
   echo "Note that you can define your defaults (myacc, autogit) in"
   echo "${HOME}/.config/mastodon-backup/config"
@@ -135,7 +143,16 @@ function report() {
   echo
 }
 
+# -----------------------------------------------------------------------------
+# find out where to look for / create our backup
+if [[ -n "$MASTOBASE" ]]; then
+  INSTDIR="${MASTOBASE}/${myacc##*@}"
+else
+  INSTDIR="${PWD}"
+fi
+
 #===[ MAIN ]===
+cd "$INSTDIR"
 # What to do?
 case "$1" in
   archive) archive && save archive;;
@@ -144,3 +161,4 @@ case "$1" in
   report) report;;
   *) syntax;;
 esac
+cd - >/dev/null

--- a/contrib/mastoarch
+++ b/contrib/mastoarch
@@ -8,6 +8,7 @@
 # -----------------------------------------------------------------------------
 # Default options (can be overridden via command-line):
 myacc="Demo@server.tld" # Your (default) Mastodon handle
+archive_followers=0     # whether to archive followers as well
 autogit=0               # whether to automatically check-in new data to your local git repo
 
 # !!! ================================================================== !!!
@@ -20,13 +21,20 @@ autogit=0               # whether to automatically check-in new data to your loc
 
 # -----------------------------------------------------------------------------
 # Evaluate command-line options
-while getopts "a:b:g:" OPT; do
+while getopts "a:b:f:g:" OPT; do
   case $OPT in
     a) myacc=$OPTARG ;;
     b) MASTOBASE="$OPTARG" ;;
+    f) case "$OPTARG" in
+         0|1) archive_followers=$OPTARG ;;
+         *) echo -e "\n! invalid value '$OPTARG' for archive_followers. -f must be 0 or 1.\n"
+            exit 1
+            ;;
+       esac
+       ;;
     g) case "$OPTARG" in
          0|1|2) autogit=$OPTARG ;;
-         *) echo "! invalid value '$OPTARG' for autogit. -g must be 0, 1 or 2."
+         *) echo -e "\n! invalid value '$OPTARG' for autogit. -g must be 0, 1 or 2.\n"
             exit 1
             ;;
        esac
@@ -82,7 +90,11 @@ fi
 # -----------------------------------------------------------------------------
 # get data from the instance
 function archive() {
-  mastodon-archive archive --with-mentions --with-following "$myacc"
+  if [[ $archive_followers -eq 1 ]]; then
+    mastodon-archive archive --with-mentions --with-following --with-followers "$myacc"
+  else
+    mastodon-archive archive --with-mentions --with-following "$myacc"
+  fi
   mastodon-archive replies "$myacc"
   mastodon-archive media --collection favourites "$myacc"
   mastodon-archive media --collection bookmarks "$myacc"

--- a/contrib/mastoarch
+++ b/contrib/mastoarch
@@ -25,8 +25,8 @@ while getopts "a:b:g:" OPT; do
     a) myacc=$OPTARG ;;
     b) MASTOBASE="$OPTARG" ;;
     g) case "$OPTARG" in
-         0|1) autogit=$OPTARG ;;
-         *) echo "! invalid value '$OPTARG' for autogit. -g must be 0 or 1."
+         0|1|2) autogit=$OPTARG ;;
+         *) echo "! invalid value '$OPTARG' for autogit. -g must be 0, 1 or 2."
             exit 1
             ;;
        esac
@@ -61,8 +61,8 @@ syntax() {
   echo "                    your account is @<username>@mastodon.example.net),"
   echo "                    otherwise they will be looked for in your current"
   echo "                    working directory (where you are when invoking this script)"
-  echo "  -g <0|1>        : whether to automatically check in changes to your local"
-  echo "                    git (0|1)"
+  echo "  -g <0|1|2>      : whether to automatically check in changes to your local"
+  echo "                    git (0: don't, 1: ask, 2: do it)"
   echo
   echo "Note that you can define your defaults (myacc, autogit) in"
   echo "${HOME}/.config/mastodon-backup/config"
@@ -98,17 +98,19 @@ function html() {
 # -----------------------------------------------------------------------------
 # add changes to local git repo
 function save() {
+  [[ $autogit -lt 1 ]] && return
   [[ ! -d .git ]] && {
     echo "No git repo found, skipping check-in."
     echo "(Use 'git init' to create a repo.)"
     return
   }
-  if [[ $autogit -eq 1 ]]; then
-    gitreply=y
-  else
-    read -n 1 -t 600 -p "run 'git add' and 'git commit' (y/n)? " gitreply
-    echo
-  fi
+  case $autogit in
+    0) gitreply=n ;;
+    1) read -n 1 -t 600 -p "run 'git add' and 'git commit' (y/n)? " gitreply
+       echo
+       ;;
+    2) gitreply=y ;;
+  esac
   [[ ${gitreply,,} = 'y' || ${gitreply,,} = 'j' ]] && {
     git add .
     git commit -m "commit for backup after run for '$1' at $(date +'%y-%m-%y %H:%M:%S')"

--- a/contrib/mastoarch
+++ b/contrib/mastoarch
@@ -92,6 +92,7 @@ function archive() {
 # generate static html from gathered data
 function html() {
   mastodon-archive html "$myacc"
+  mastodon-archive html --collection bookmarks "$myacc"
   mastodon-archive html --collection favourites "$myacc"
 }
 

--- a/contrib/mastoarch
+++ b/contrib/mastoarch
@@ -15,6 +15,10 @@ autogit=0               # whether to automatically check-in new data to your loc
 # !!! ================================================================== !!!
 
 # -----------------------------------------------------------------------------
+# Load config if exists
+[[ -f "${HOME}/.config/mastodon-backup/config" ]] && source "${HOME}/.config/mastodon-backup/config"
+
+# -----------------------------------------------------------------------------
 # Evaluate command-line options
 while getopts "a:g:" OPT; do
   case $OPT in
@@ -51,6 +55,9 @@ syntax() {
   echo "Options:"
   echo "  -g <0|1>    : whether to automatically check in changes to your local git (0|1)"
   echo "  -a <handle> : Mastodon handle (user) to process"
+  echo
+  echo "Note that you can define your defaults (myacc, autogit) in"
+  echo "${HOME}/.config/mastodon-backup/config"
   echo
 }
 

--- a/contrib/mastodon-archive
+++ b/contrib/mastodon-archive
@@ -1,2 +1,2 @@
 #!/bin/bash
-/usr/lib/python3/dist-packages/mastodon-backup/mastodon-archive.py $*
+/usr/lib/python3/dist-packages/mastodon_archive/mastodon-archive.py $*

--- a/contrib/mastosearch
+++ b/contrib/mastosearch
@@ -10,7 +10,7 @@ viewer=
 
 # -----------------------------------------------------------------------------
 # Load config if exists
-[[ -f "${HOME}/.config/mastodon-backup/config" ]] && source "${HOME}/.config/mastodon-backup/config"
+[[ -f "${HOME}/.config/mastodon-archive/config" ]] && source "${HOME}/.config/mastodon-archive/config"
 
 # -----------------------------------------------------------------------------
 # Evaluate command-line options
@@ -83,7 +83,7 @@ syntax() {
   echo "                    available on your system."
   echo
   echo "Note that you can define your defaults (MASTOBASE, myacc) in"
-  echo "${HOME}/.config/mastodon-backup/config"
+  echo "${HOME}/.config/mastodon-archive/config"
   echo
 }
 
@@ -100,7 +100,7 @@ else
 fi
 [[ "$myacc" = "Demo@Mastodon.example.net" ]] && {
   echo "You need to configure your default account (either at the top of this script or"
-  echo "in '${HOME}/.config/mastodon-backup/config') or pass an account using the '-a' option."
+  echo "in '${HOME}/.config/mastodon-archive/config') or pass an account using the '-a' option."
   echo
   exit 2
 }

--- a/contrib/mastosearch
+++ b/contrib/mastosearch
@@ -117,7 +117,7 @@ if [[ -n "$viewer" ]]; then
   if [[ -n "$context" ]]; then
     mastodon-archive context $myacc $context | markdown | $viewer
   elif [[ -n "$follower" ]]; then
-    jq --arg search "$follower" '.followers[] | select(any(. | strings | test($search; "i")))' ${myacc##*@}.user.${myacc%%@*}.json | $viewer
+    jq --arg search "$follower" '.followers[] | select(any(. | strings | test($search; "i")))' ${myacc##*@}.user.${myacc%%@*}.json | echo -e "\`\`\`\n$(</dev/stdin)\n\`\`\`\n" | markdown | sed 's!<code>!<pre>!;s!</code>!</pre>!' | $viewer
   else
     mastodon-archive text $colls $myacc $* | markdown | $viewer
   fi

--- a/contrib/mastosearch
+++ b/contrib/mastosearch
@@ -16,7 +16,8 @@ viewer=
 # Evaluate command-line options
 colls=
 context=
-while getopts "a:b:c:t:v:" OPT; do
+follower=
+while getopts "a:b:c:f:t:v:" OPT; do
   case $OPT in
     a) myacc=$OPTARG ;;
     b) MASTOBASE="$OPTARG" ;;
@@ -29,6 +30,7 @@ while getopts "a:b:c:t:v:" OPT; do
          *)         echo "ignoring unknown collection '$OPTARG'"
        esac
        ;;
+    f) follower="$OPTARG" ;;
     t) context="$OPTARG" ;;
     v) viewer="$OPTARG" ;;
     *) $0 ; exit 1 ;;
@@ -63,12 +65,16 @@ syntax() {
   echo "                    working directory (where you are when invoking this script)"
   echo "  -c <collection> : search specified collection. Valid collections:"
   echo "                    favorites, bookmarks, mentions, statuses, all"
+  echo "  -f <searchTerm> : search your followers. Requires followers to be archived"
+  echo "                    and the 'jq' tool being available. Search will always be"
+  echo "                    case insensitive. Returns JSON."
+  echo "                    Cannot be combined with -c or -t."
+  echo "  -t <statusUrl>  : thread (conText) search. <statusUrl> is the link to a status"
+  echo "                    which shall be shown with its context."
   echo "  -v <viewer>     : display results with a self-defined viewer, e.g. Lynx."
   echo "                    The viewer needs to accept HTML from standard input, and"
   echo "                    this feature also needs the 'markdown' command being"
   echo "                    available on your system."
-  echo "  -t <statusUrl>  : thread (conText) search. <statusUrl> is the link to a status"
-  echo "                    which shall be shown with its context."
   echo
   echo "Note that you can define your defaults (MASTOBASE, myacc) in"
   echo "${HOME}/.config/mastodon-backup/config"
@@ -98,7 +104,7 @@ fi
   echo
   exit 5
 }
-[[ -z "$1" && -z "$context" ]] && {
+[[ -z "$1" && -z "$context" && -z "$follower" ]] && {
   syntax
   exit;
 }
@@ -110,12 +116,16 @@ cd "${INSTDIR}"
 if [[ -n "$viewer" ]]; then
   if [[ -n "$context" ]]; then
     mastodon-archive context $myacc $context | markdown | $viewer
+  elif [[ -n "$follower" ]]; then
+    jq --arg search "$follower" '.followers[] | select(any(. | strings | test($search; "i")))' ${myacc##*@}.user.${myacc%%@*}.json | $viewer
   else
     mastodon-archive text $colls $myacc $* | markdown | $viewer
   fi
 else
   if [[ -n "$context" ]]; then
     mastodon-archive context $myacc $context
+  elif [[ -n "$follower" ]]; then
+    jq --arg search "$follower" '.followers[] | select(any(. | strings | test($search; "i")))' ${myacc##*@}.user.${myacc%%@*}.json
   else
     mastodon-archive text $colls $myacc $*
   fi

--- a/contrib/mastosearch
+++ b/contrib/mastosearch
@@ -17,7 +17,8 @@ viewer=
 colls=
 context=
 follower=
-while getopts "a:b:c:f:t:v:" OPT; do
+following=
+while getopts "a:b:c:f:F:t:v:" OPT; do
   case $OPT in
     a) myacc=$OPTARG ;;
     b) MASTOBASE="$OPTARG" ;;
@@ -30,7 +31,8 @@ while getopts "a:b:c:f:t:v:" OPT; do
          *)         echo "ignoring unknown collection '$OPTARG'"
        esac
        ;;
-    f) follower="$OPTARG" ;;
+    F) follower="$OPTARG" ;;
+    f) following="$OPTARG" ;;
     t) context="$OPTARG" ;;
     v) viewer="$OPTARG" ;;
     *) $0 ; exit 1 ;;
@@ -65,7 +67,11 @@ syntax() {
   echo "                    working directory (where you are when invoking this script)"
   echo "  -c <collection> : search specified collection. Valid collections:"
   echo "                    favorites, bookmarks, mentions, statuses, all"
-  echo "  -f <searchTerm> : search your followers. Requires followers to be archived"
+  echo "  -f <searchTerm> : search your followings. Requires followers to be archived"
+  echo "                    and the 'jq' tool being available. Search will always be"
+  echo "                    case insensitive. Returns JSON."
+  echo "                    Cannot be combined with -c or -t."
+  echo "  -F <searchTerm> : search your followers. Requires followers to be archived"
   echo "                    and the 'jq' tool being available. Search will always be"
   echo "                    case insensitive. Returns JSON."
   echo "                    Cannot be combined with -c or -t."
@@ -104,7 +110,7 @@ fi
   echo
   exit 5
 }
-[[ -z "$1" && -z "$context" && -z "$follower" ]] && {
+[[ -z "$1" && -z "${context}${follower}${following}" ]] && {
   syntax
   exit;
 }
@@ -117,7 +123,9 @@ if [[ -n "$viewer" ]]; then
   if [[ -n "$context" ]]; then
     mastodon-archive context $myacc $context | markdown | $viewer
   elif [[ -n "$follower" ]]; then
-    jq --arg search "$follower" '.followers[] | select(any(. | strings | test($search; "i")))' ${myacc##*@}.user.${myacc%%@*}.json | echo -e "\`\`\`\n$(</dev/stdin)\n\`\`\`\n" | markdown | sed 's!<code>!<pre>!;s!</code>!</pre>!' | $viewer
+    jq --arg search "$follower" '.followers[] | select(any(. | strings | test($search; "i")))' ${myacc##*@}.user.${myacc%%@*}.json | echo -e "\`\`\`\n$(cat)\n\`\`\`\n" | markdown | sed 's!<code>!<pre>!;s!</code>!</pre>!' | $viewer
+  elif [[ -n "$following" ]]; then
+    jq --arg search "$following" '.following[] | select(any(. | strings | test($search; "i")))' ${myacc##*@}.user.${myacc%%@*}.json | echo -e "\`\`\`\n$(cat)\n\`\`\`\n" | markdown | sed 's!<code>!<pre>!;s!</code>!</pre>!' | $viewer
   else
     mastodon-archive text $colls $myacc $* | markdown | $viewer
   fi
@@ -126,6 +134,8 @@ else
     mastodon-archive context $myacc $context
   elif [[ -n "$follower" ]]; then
     jq --arg search "$follower" '.followers[] | select(any(. | strings | test($search; "i")))' ${myacc##*@}.user.${myacc%%@*}.json
+  elif [[ -n "$following" ]]; then
+    jq --arg search "$following" '.following[] | select(any(. | strings | test($search; "i")))' ${myacc##*@}.user.${myacc%%@*}.json
   else
     mastodon-archive text $colls $myacc $*
   fi

--- a/contrib/mastosearch
+++ b/contrib/mastosearch
@@ -1,0 +1,123 @@
+#!/bin/bash
+# search our local mastodon archive
+# © 2022 Izzy <izzysoft AT qumran DOT org>; GPL-3.0-or-later
+
+# -----------------------------------------------------------------------------
+# Defaults
+MASTOBASE=
+myacc=Demo@Mastodon.example.net
+viewer=
+
+# -----------------------------------------------------------------------------
+# Load config if exists
+[[ -f "${HOME}/.config/mastodon-backup/config" ]] && source "${HOME}/.config/mastodon-backup/config"
+
+# -----------------------------------------------------------------------------
+# Evaluate command-line options
+colls=
+context=
+while getopts "a:b:c:t:v:" OPT; do
+  case $OPT in
+    a) myacc=$OPTARG ;;
+    b) MASTOBASE="$OPTARG" ;;
+    c) case "$OPTARG" in
+         favorites) colls="$colls --collection favorites" ;;
+         mentions)  colls="$colls --collection mentions" ;;
+         bookmarks) colls="$colls --collection bookmarks" ;;
+         statuses)  colls="$colls --collection statuses" ;;
+         all)       colls="--collection all" ;;
+         *)         echo "ignoring unknown collection '$OPTARG'"
+       esac
+       ;;
+    t) context="$OPTARG" ;;
+    v) viewer="$OPTARG" ;;
+    *) $0 ; exit 1 ;;
+  esac
+done
+shift $(($OPTIND - 1))
+
+# -----------------------------------------------------------------------------
+# show help
+syntax() {
+  echo
+  echo "Mastodon Searcher"
+  echo "================="
+  echo
+  echo "Syntax:"
+  echo "  $0 [options] <searchRegEx> [<searchRegEx> ...]"
+  echo "  $0 -t <statusUrl> [-l]"
+  echo
+  echo "SearchRegEx:"
+  echo "  - a single search term, e.g. 'book'"
+  echo "  - a RegEx term, e.g. 'e?book\b'"
+  echo "  - a time frame, e.g. 2017-(07|08|09|10|11)' (useful as 2nd term)"
+  echo "  - a phrase, e.g. '(?i)android book'"
+  echo
+  echo "Options:"
+  echo "  -a <handle>     : Mastodon handle (user) to process"
+  echo "  -b <MASTOBASE>  : base where all our backups reside. If specified,"
+  echo "                    your backups are expected in MASTOBASE/<instanceName>"
+  echo "                    (e.g. /home/peter/mastodon/mastodon.example.net if"
+  echo "                    your account is @<username>@mastodon.example.net),"
+  echo "                    otherwise they will be looked for in your current"
+  echo "                    working directory (where you are when invoking this script)"
+  echo "  -c <collection> : search specified collection. Valid collections:"
+  echo "                    favorites, bookmarks, mentions, statuses, all"
+  echo "  -v <viewer>     : display results with a self-defined viewer, e.g. Lynx."
+  echo "                    The viewer needs to accept HTML from standard input, and"
+  echo "                    this feature also needs the 'markdown' command being"
+  echo "                    available on your system."
+  echo "  -t <statusUrl>  : thread (conText) search. <statusUrl> is the link to a status"
+  echo "                    which shall be shown with its context."
+  echo
+  echo "Note that you can define your defaults (MASTOBASE, myacc) in"
+  echo "${HOME}/.config/mastodon-backup/config"
+  echo
+}
+
+# -----------------------------------------------------------------------------
+# evaluate settings
+if [[ -n "$viewer" && -z "$(which $(echo $viewer | awk '{print $1}'))" ]]; then
+  echo -e "\n'$(echo $viewer | awk '{print $1}')' not found, resetting viewer.\n"
+  viewer=
+fi
+if [[ -n "$MASTOBASE" ]]; then
+  INSTDIR="${MASTOBASE}/${myacc##*@}"
+else
+  INSTDIR="${PWD}"
+fi
+[[ "$myacc" = "Demo@Mastodon.example.net" ]] && {
+  echo "You need to configure your default account (either at the top of this script or"
+  echo "in '${HOME}/.config/mastodon-backup/config') or pass an account using the '-a' option."
+  echo
+  exit 2
+}
+[[ ! -f "${INSTDIR}/${myacc##*@}.user.${myacc%%@*}.json" ]] && {
+  echo "Could not find '${INSTDIR}/${myacc##*@}.user.${myacc%%@*}.json'."
+  echo "Maybe you did not yet create a backup?"
+  echo
+  exit 5
+}
+[[ -z "$1" && -z "$context" ]] && {
+  syntax
+  exit;
+}
+
+
+# -----------------------------------------------------------------------------
+# Do it!
+cd "${INSTDIR}"
+if [[ -n "$viewer" ]]; then
+  if [[ -n "$context" ]]; then
+    mastodon-archive context $myacc $context | markdown | $viewer
+  else
+    mastodon-archive text $colls $myacc $* | markdown | $viewer
+  fi
+else
+  if [[ -n "$context" ]]; then
+    mastodon-archive context $myacc $context
+  else
+    mastodon-archive text $colls $myacc $*
+  fi
+fi
+cd - > /dev/null


### PR DESCRIPTION
* add a new script to ease searches (`mastosearch`)
* add a config file to define defaults for `mastoarch` and `mastosearch`
* update contrib's README accordingly

Gimmick: with `mastosearch`, using the `viewer` parameter (and having the `markdown` package installed) results can be shown in a browser that accepts input from STDIN – e.g. lynx(see example). Not yet tested: other browsers. There are some [examples for Firefox](https://unix.stackexchange.com/q/24931/209279), but that might be overdoing it :wink: 