### PR TITLE
fix typo from renaming (mastodon-backup => mastodon-archive)

### DIFF
--- a/contrib/mastodon-archive
+++ b/contrib/mastodon-archive
@@ -1,2 +1,2 @@
 #!/bin/bash
-/usr/lib/python3/dist-packages/mastodon_archive/mastodon-archive.py $*
+/usr/lib/python3/dist-packages/mastodon-archive/mastodon-archive.py $*


### PR DESCRIPTION
Oops… noticed when checking the renamed packages, there's a typo from renaming :see_no_evil: