### PR TITLE
Fix typo (data_handler -> date_handler)

### DIFF
--- a/mastodon_archive/archive.py
+++ b/mastodon_archive/archive.py
@@ -95,7 +95,7 @@ def archive(args):
                     return False
             return True
         elif d1 := core.date_handler(item1):
-            return True if d1 == item2 else d1 == core.data_handler(item2)
+            return True if d1 == item2 else d1 == core.date_handler(item2)
         elif d2 := core.date_handler(item1):
             return item1 == d2
 


### PR DESCRIPTION
Fix a typo in an earlier patch submitted by me. Don't know why this wasn't caught in my testing but just ran into it in the wild so here's a fix.