### PR TITLE
Remove version_check agument to App() call from login(), change default to none

### DIFF
--- a/mastodon_archive/core.py
+++ b/mastodon_archive/core.py
@@ -102,7 +102,7 @@ class App:
     account.
     """
 
-    def __init__(self, user, scopes=('read',), name="mastodon-archive", pace=False, version_check="created"):
+    def __init__(self, user, scopes=('read',), name="mastodon-archive", pace=False, version_check="none"):
 
         self.username, self.domain = user.split("@")
         self.url = "https://" + self.domain

--- a/mastodon_archive/core.py
+++ b/mastodon_archive/core.py
@@ -93,8 +93,7 @@ def login(args, scopes=('read',)):
     Login to your Mastodon account.
     """
     pace = hasattr(args, 'pace') and args.pace
-    version_check = hasattr(args, 'version_check') and args.version_check
-    app = App(args.user, scopes=scopes, pace=pace, version_check=version_check)
+    app = App(args.user, scopes=scopes, pace=pace)
     return app.login()
 
 class App:


### PR DESCRIPTION
As suggested [here](https://github.com/kensanata/mastodon-archive/issues/130#issuecomment-3723333894), this removes this extra argument handling in `login()` such that `version_check` will always be the default of the `App()` function.

It seems to me that keeping the default in the code makes sense to support troubleshooting / workarounds.

Also change the default to `none`.

As mentioned before, I do not consider myself a pythonista and am proposing this trivial patch only to help out.