### PR TITLE
Partially fix #133: handle 'File name too long' for very long attachment URLs

### DIFF
--- a/mastodon_archive/media.py
+++ b/mastodon_archive/media.py
@@ -137,8 +137,8 @@ def media(args):
                 bar.next()
             path = urlparse(url).path
             dir_name =  os.path.dirname(file_name)
-            os.makedirs(dir_name, exist_ok = True)
             try:
+                os.makedirs(dir_name, exist_ok = True)
                 if download(url, remoteurl, file_name, args):
                     succeeded += 1
                 else:


### PR DESCRIPTION
That is an OSError, which the try block handles already.

Before, OSError when creating the directory would interrupt the media download process.