### PR TITLE
archive --with-notes shouldn't overwrite value of "account" in archive

### DIFF
--- a/mastodon_archive/archive.py
+++ b/mastodon_archive/archive.py
@@ -346,8 +346,8 @@ def archive(args):
             print("Get notes (this may take a while)")
         all_ids = set()
         for coll in (followers, following, mutes, blocks):
-            for user in coll:
-                all_ids.add(user['id'])
+            for coll_user in coll:
+                all_ids.add(coll_user['id'])
         all_ids = list(all_ids)
         # If there are too many IDs the call may fail because the URI is too
         # long, so we use binary back-off to find a request size that works.


### PR DESCRIPTION
Previously, if `mastodon-archive` was run with `--with-notes`, then the code for archiving notes overwrote the `user` variable which was supposed to contain the user whose account was being archived, thus causing some random user's account to be saved in the `account` section of the archive, instead of saving the correct user. This commit changes the `--with-notes` code to use a different variable so the correct user's account information is saved in the archive.